### PR TITLE
Fix: Handle null role on login and signup

### DIFF
--- a/Event-management/Event-Booking-System/src/main/java/com/bluepal/service/AuthServiceImpl.java
+++ b/Event-management/Event-Booking-System/src/main/java/com/bluepal/service/AuthServiceImpl.java
@@ -75,12 +75,16 @@ public class AuthServiceImpl implements IAuthService {
         createdUser.setMobileNo1(createUserReq.getMobileNo1());
         createdUser.setMobileNo2(createUserReq.getMobileNo2());
         createdUser.setPassword(passwordEncoder.encode(createUserReq.getPassword()));
-        createdUser.setRole(createUserReq.getRole());
+        if (createUserReq.getRole() == null || createUserReq.getRole().isEmpty()) {
+            createdUser.setRole(USER_ROLE.ROLE_USER.toString());
+        } else {
+            createdUser.setRole(createUserReq.getRole());
+        }
 
         UserModel savedUser = userRepo.save(createdUser);
 
-        createdUser.setCreatedBy(savedUser.getId());
-        userRepo.save(createdUser);
+        savedUser.setCreatedBy(savedUser.getId());
+        userRepo.save(savedUser);
 
         log.info(appProperties.getSignupUserCreated(), savedUser.getEmail());
 

--- a/Event-management/Event-Booking-System/src/main/java/com/bluepal/service/CustomUserServiceImpl.java
+++ b/Event-management/Event-Booking-System/src/main/java/com/bluepal/service/CustomUserServiceImpl.java
@@ -34,6 +34,9 @@ public class CustomUserServiceImpl  implements UserDetailsService{
 		}
 		
 		USER_ROLE role = user.getRole();
+		if (role == null) {
+			role = USER_ROLE.ROLE_USER;
+		}
 	
 		List<GrantedAuthority> authorities =new ArrayList<>();
 		


### PR DESCRIPTION
This commit fixes a 500 Internal Server Error that occurred during login. The error was caused by a NullPointerException when the application tried to access the role of a user, and the role was null.

The fix includes two parts:
1.  In `AuthServiceImpl`, a default role of `ROLE_USER` is assigned to new users if no role is specified during signup.
2.  In `CustomUserServiceImpl`, a null check is added to handle existing users in the database who have a null role, defaulting to `ROLE_USER`.